### PR TITLE
Enable lamy plugin by overriding xochitl service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,9 @@ ZONEINFO_DIR="/usr/share/zoneinfo/"
 
 uninstall () {
     rm -rf ${CACHE_DIR}*
+
+    rm -rf /etc/systemd/system/xochitl.service.d
+    rm /usr/lib/plugins/generic/libqevdevlamyplugin.so || true
 }
 
 
@@ -75,7 +78,13 @@ install_stylus () {
     resp=$?
     set -e
     if [ "$resp" -eq "0" ]; then
-        sh -c "$(wget https://raw.githubusercontent.com/ddvk/remarkable-stylus/master/patch.sh -O-)"
+        wget "https://github.com/ddvk/remarkable-stylus/releases/download/0.0.3/libqevdevlamyplugin.so" -O /usr/lib/plugins/generic/libqevdevlamyplugin.so
+        mkdir -p /etc/systemd/system/xochitl.service.d
+        cat << EOF > /etc/systemd/system/xochitl.service.d/evdevlamy.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/xochitl --system -plugin evdevlamy
+EOF
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -15,9 +15,15 @@ ZONEINFO_DIR="/usr/share/zoneinfo/"
 uninstall () {
     rm -rf ${CACHE_DIR}*
 
-    rm /etc/systemd/system/xochitl.service.d/evdevlamy.conf 2>/dev/null || true
-    rmdir /etc/systemd/system/xochitl.service.d 2>/dev/null || true
-    rm /usr/lib/plugins/generic/libqevdevlamyplugin.so 2>/dev/null || true
+    if [ -f "/etc/systemd/system/xochitl.service.d/evdevlamy.conf" ]; then
+        rm /etc/systemd/system/xochitl.service.d/evdevlamy.conf
+    fi
+    if [ -z "$(ls -A /etc/systemd/system/xochitl.service.d)" ]; then
+        rmdir /etc/systemd/system/xochitl.service.d
+    fi
+    if [ -f "/usr/lib/plugins/generic/libqevdevlamyplugin.so" ]; then
+        rm /usr/lib/plugins/generic/libqevdevlamyplugin.so
+    fi
 }
 
 

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,9 @@ ZONEINFO_DIR="/usr/share/zoneinfo/"
 uninstall () {
     rm -rf ${CACHE_DIR}*
 
-    rm -rf /etc/systemd/system/xochitl.service.d
-    rm /usr/lib/plugins/generic/libqevdevlamyplugin.so || true
+    rm /etc/systemd/system/xochitl.service.d/evdevlamy.conf 2>/dev/null || true
+    rmdir /etc/systemd/system/xochitl.service.d 2>/dev/null || true
+    rm /usr/lib/plugins/generic/libqevdevlamyplugin.so 2>/dev/null || true
 }
 
 


### PR DESCRIPTION
Install and unisntall `ddvk/remarkable-stylus` Lamy Plugin in more controlled way without the need to fully overwrite the `xochitl.service` but by overriding the exec command only.