### PR TITLE
Release patch v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,18 @@ sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh 
 
 | Version |    3.7.0.1930    |    3.6.1.1894    |
 |  :---:  |       :---:      |       :---:      |
+|**0.0.4**|:white_check_mark:|        :x:       |
 |**0.0.3**|:white_check_mark:|        :x:       |
 |**0.0.2**|:white_check_mark:|        :x:       |
 |**0.0.1**|:white_check_mark:|:white_check_mark:|
+
+### Version 0.0.4
+
+This patch includes all the hacks from the previous one, along with the following:
+
+- Additional stroke sizes (0.5, 1, 1.5, 2, 3, 5, 8, 13).
+- Gesture to switch between the last two tools: swipe one finger down in the top left corner.
+- Gesture to switch between the writing tool and eraser: swipe one finger up in the top left corner.
 
 ### Version 0.0.3
 

--- a/install.sh
+++ b/install.sh
@@ -36,10 +36,10 @@ find_version () {
             patch_version="0.0.1"
             ;;
         "ae0d21c258c0f3d93717d9bd23eb74b68ac438db")
-            patch_version="0.0.3"
+            patch_version="0.0.4"
             ;;
         "4d066636ed653ffe59d4bc3acf55aa6cef72d795")
-            patch_version="0.0.3"
+            patch_version="0.0.4"
             ;;
     esac
 }


### PR DESCRIPTION
- Additional stroke sizes (0.5, 1, 1.5, 2, 3, 5, 8, 13).
- Gesture to switch between the last two tools: swipe one finger down in the top left corner.
- Gesture to switch between the writing tool and eraser: swipe one finger up in the top left corner.

To test it you may run `sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh -O-)" _ patch 0.0.4`.

Should fix #9 and #10.