### PR TITLE
Prepare install and readme for v0.0.5-3.8.2.1965

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh 
 
 ## Patches
 
-| Version |    3.7.0.1930    |    3.6.1.1894    |
-|  :---:  |       :---:      |       :---:      |
-|**0.0.5**|:white_check_mark:|        :x:       |
-|**0.0.4**|:white_check_mark:|        :x:       |
-|**0.0.3**|:white_check_mark:|        :x:       |
-|**0.0.2**|:white_check_mark:|        :x:       |
-|**0.0.1**|:white_check_mark:|:white_check_mark:|
+| Version |    3.8.2.1965    |    3.7.0.1930    |    3.6.1.1894    |
+|  :---:  |       :---:      |       :---:      |       :---:      |
+|**0.0.5**|:white_check_mark:|:white_check_mark:|        :x:       |
+|**0.0.4**|        :x:       |:white_check_mark:|        :x:       |
+|**0.0.3**|        :x:       |:white_check_mark:|        :x:       |
+|**0.0.2**|        :x:       |:white_check_mark:|        :x:       |
+|**0.0.1**|        :x:       |:white_check_mark:|:white_check_mark:|
 
 ### Version 0.0.5
 

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,12 @@ find_version () {
         "4d066636ed653ffe59d4bc3acf55aa6cef72d795")
             patch_version="0.0.5"
             ;;
+        "830732bd53c8c94d73013a238ca0427a6c9a252f")
+            patch_version="0.0.5"
+            ;;
+        "ceba98d368cc16aa6af806243969a3ba88c13bd1")
+            patch_version="0.0.5"
+            ;;
     esac
 }
 


### PR DESCRIPTION
Hacks for 3.8.2.1965 are around the corner. You may test them right now by issuing:

```shell
sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh -O-)" _ patch 0.0.5
```

Your feedback is highly appreciated!

Closes #44