### PR TITLE
Prepare v0.0.7 release for 3.8.2.1965

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh 
 
 | Version |    3.8.2.1965    |    3.7.0.1930    |    3.6.1.1894    |
 |  :---:  |       :---:      |       :---:      |       :---:      |
+|**0.0.7**|:white_check_mark:|        :x:       |        :x:       |
 |**0.0.6**|:white_check_mark:|        :x:       |        :x:       |
 |**0.0.5**|:white_check_mark:|:white_check_mark:|        :x:       |
 |**0.0.4**|        :x:       |:white_check_mark:|        :x:       |
@@ -68,6 +69,31 @@ sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh 
 
 If you're still using a device with version 2.x, you might prefer using
 [ddvk's Binary Patches](https://github.com/ddvk/remarkable-hacks).
+
+### Version 0.0.7
+
+This patch includes all the hacks from the previous one, along with the following:
+
+#### New features:
+
+- Toolbar button showing the current page and the page count, clicking it opens fast page scroll.
+- Battery level and WiFi signal strength indicators available on the bottom of the toolbar.
+- Screen refresh trigger via five-finger tap - natively available but disabled by experimental flag.
+- Additional table-of-contents toolbar button.
+- Enable sleep mode by swiping up from the top of the screen (light or deep sleep selectable in Settings/Security).
+- Display `...zzZ` in the top right corner during light sleep mode instead of a big black banner.
+
+#### Bug fixes:
+
+- Configuration items may be scrolled vertically.
+- Pen thickness and color indicator show only for the tools that make use of them.
+- All the tools remember last two strokes and colors separately.
+
+#### Other changes:
+
+- Document-level clock moved from the bottom to the top of the toolbar.
+- Make clock toggle option permanent between restarts.
+- Changed names of document-level toggles (i.e. remove "Disabled" and "Enabled" words).
 
 ### Version 0.0.6
 

--- a/install.sh
+++ b/install.sh
@@ -42,10 +42,10 @@ find_version () {
             patch_version="0.0.5"
             ;;
         "830732bd53c8c94d73013a238ca0427a6c9a252f")
-            patch_version="0.0.6"
+            patch_version="0.0.7"
             ;;
         "ceba98d368cc16aa6af806243969a3ba88c13bd1")
-            patch_version="0.0.6"
+            patch_version="0.0.7"
             ;;
     esac
 }


### PR DESCRIPTION
### New features:

- Toolbar button showing the current page and the page count, clicking it opens fast page scroll (see #55).
- Battery level and WiFi signal strength indicators available on the bottom of the toolbar (closes #56).
- Screen refresh trigger via five-finger tap - natively available but disabled by experimental flag (closes #57).
- Additional table-of-contents toolbar button (closes #65).
- Enable sleep mode by swiping up from the top of the screen (light or deep sleep selectable in Settings/Security) (closes #74).
- Display `...zzZ` in the top right corner during light sleep mode instead of a big black banner (see #74).

### Bug fixes:

- Configuration items may be scrolled vertically (closes #51).
- Pen thickness and color indicator show only for the tools that make use of them (closes #52).
- All the tools remember last two strokes and colors separately (closes #58).

### Other changes:

- Document-level clock moved from the bottom to the top of the toolbar.
- Make clock toggle option permanent between restarts.
- Changed names of document-level toggles (i.e. remove "Disabled" and "Enabled" words).

---

```sh
sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh -O-)" _ patch 0.0.7
```