### PR TITLE
Prepare v0.0.7 release for 3.8.3.1976

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh 
 
 ## Patches
 
-| Version |    3.8.2.1965    |    3.7.0.1930    |    3.6.1.1894    |
-|  :---:  |       :---:      |       :---:      |       :---:      |
-|**0.0.7**|:white_check_mark:|        :x:       |        :x:       |
-|**0.0.6**|:white_check_mark:|        :x:       |        :x:       |
-|**0.0.5**|:white_check_mark:|:white_check_mark:|        :x:       |
-|**0.0.4**|        :x:       |:white_check_mark:|        :x:       |
-|**0.0.3**|        :x:       |:white_check_mark:|        :x:       |
-|**0.0.2**|        :x:       |:white_check_mark:|        :x:       |
-|**0.0.1**|        :x:       |:white_check_mark:|:white_check_mark:|
+| Version |    3.8.3.1976    |    3.8.2.1965    |    3.7.0.1930    |    3.6.1.1894    |
+|  :---:  |       :---:      |       :---:      |       :---:      |       :---:      |
+|**0.0.7**|:white_check_mark:|:white_check_mark:|        :x:       |        :x:       |
+|**0.0.6**|        :x:       |:white_check_mark:|        :x:       |        :x:       |
+|**0.0.5**|        :x:       |:white_check_mark:|:white_check_mark:|        :x:       |
+|**0.0.4**|        :x:       |        :x:       |:white_check_mark:|        :x:       |
+|**0.0.3**|        :x:       |        :x:       |:white_check_mark:|        :x:       |
+|**0.0.2**|        :x:       |        :x:       |:white_check_mark:|        :x:       |
+|**0.0.1**|        :x:       |        :x:       |:white_check_mark:|:white_check_mark:|
 
 If you're still using a device with version 2.x, you might prefer using
 [ddvk's Binary Patches](https://github.com/ddvk/remarkable-hacks).

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,9 @@ find_version () {
         "ceba98d368cc16aa6af806243969a3ba88c13bd1")
             patch_version="0.0.7"
             ;;
+        "03af9c2bf1173b6397e89955624300ae987f7ac0")
+            patch_version="0.0.7"
+            ;;
     esac
 }
 


### PR DESCRIPTION
Thanks to @ard0gg I am able to bring  **v0.0.7** to **rM2** devices updated to **3.8.3.1976**.

```sh
sh -c "$(wget https://raw.githubusercontent.com/mb1986/rm-hacks/main/install.sh -O-)" _ patch 0.0.7
```

It is already ready for testing!

Closes #68